### PR TITLE
Fixing for home assistant >=0.89

### DIFF
--- a/homeassistant/components/climate/vaillant.py
+++ b/homeassistant/components/climate/vaillant.py
@@ -11,8 +11,9 @@ import voluptuous as vol
 from homeassistant.const import (
      TEMP_CELSIUS, ATTR_TEMPERATURE)
 from homeassistant.components.climate import (
-    STATE_HEAT, STATE_IDLE, ClimateDevice, PLATFORM_SCHEMA,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE, SUPPORT_AWAY_MODE)
+     ClimateDevice, PLATFORM_SCHEMA)
+from homeassistant.components.climate.const import (
+     STATE_HEAT, STATE_IDLE, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE, SUPPORT_AWAY_MODE)
 from homeassistant.util import Throttle
 from homeassistant.loader import get_component
 import homeassistant.helpers.config_validation as cv


### PR DESCRIPTION
Hi Samuel,

I have been using your component for a while and I have to thank you for making it. It stopped working on home assistant 0.89 due to a change on some constants. These PR is to fix that.

BTW, are you planing to integrate your component on Home Assistant? If I can help in any way just let me know.

Thanks,